### PR TITLE
Add GitHub Actions workflows for coding standards and unit tests

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,61 @@
+name: Coding Standards
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    name: Coding Standards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@2.32.0
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        id: composer-cache-dir
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+          echo "npm-version=$(npm -v)" >> $GITHUB_OUTPUT
+          echo "node-version=$(node -v)" >> $GITHUB_OUTPUT
+
+      - name: Cache PHP dependencies
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-composer-8.1-${{ hashFiles('composer.lock') }}
+
+      - name: Cache Node dependencies
+        id: npm-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install PHP dependencies
+        run: |
+          composer install --prefer-dist --no-progress --no-suggest --no-interaction
+
+      - name: Install Node dependencies
+        run: npm ci --legacy-peer-deps
+
+      # Test the coding standards.
+      - name: Run the tests
+        run: |
+          npm run lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,74 @@
+name: Unit Tests
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Paths filters
+        uses: dorny/paths-filter@v2
+        id: paths
+        with:
+          filters: |
+            workflows: &workflows
+              - '.github/workflows/**/*.yml'
+            composer: &composer
+              - *workflows
+              - 'composer.json'
+              - 'composer.lock'
+            php: &php
+              - *workflows
+              - *composer
+              - '**/*.php'
+            phpunit:
+              - *workflows
+              - *php
+              - 'phpunit.xml.dist'
+
+      - name: Install PHP
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        uses: shivammathur/setup-php@2.32.0
+        with:
+          php-version: "8.1"
+          coverage: none
+          tools: composer:v2
+
+      - name: Get Composer cache directory
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        id: composer-cache-dir
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache PHP dependencies
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-composer-8.1-${{ hashFiles('composer.lock') }}
+
+      - name: Cache Docker images.
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: ${{ runner.os }}-composer-8.2-${{ hashFiles('composer.lock') }}
+
+      - name: Install PHP dependencies
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        run: |
+          composer install --no-progress --no-suggest --no-interaction
+
+      - name: Run the tests
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        run: |
+          npm run server start && npm run test-unit-php


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate coding standards checks and unit tests. The workflows are configured to run on specific branches and include steps to set up dependencies and cache directories.

New GitHub Actions workflows:

* [`.github/workflows/coding-standards.yml`](diffhunk://#diff-dfd15ae70247bb45f121522ec2e50e5da9aed17e23116d94ec887a4769c44294R1-R61): Adds a workflow for checking coding standards, including steps to install PHP and Node dependencies, cache directories, and run linting tests.
* [`.github/workflows/unit-tests.yml`](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R1-R74): Adds a workflow for running unit tests, including steps to install PHP dependencies, cache directories, and run unit tests with conditional execution based on file changes.